### PR TITLE
Comparison of the amount of code with and without using constate

### DIFF
--- a/react-context-constate-sandbox/package.json
+++ b/react-context-constate-sandbox/package.json
@@ -6,6 +6,7 @@
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^13.0.0",
     "@testing-library/user-event": "^13.2.1",
+    "constate": "^3.3.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",

--- a/react-context-constate-sandbox/src/DivideContextWithConstate.jsx
+++ b/react-context-constate-sandbox/src/DivideContextWithConstate.jsx
@@ -1,8 +1,5 @@
-import { createContext, useCallback, useContext, useState } from "react";
-
-// Context を、参照が変更する　count用 と 参照が変わらない increment 関数用の２つ作成する
-const CountContext = createContext({});
-const IncrementContext = createContext({});
+import constate from "constate";
+import { useCallback, useState } from "react";
 
 // countと、increment を定義して返却するカスタムフックス
 function useCounter({ initialCount = 0 } = {}) {
@@ -11,25 +8,11 @@ function useCounter({ initialCount = 0 } = {}) {
   return { count, increment };
 }
 
-// ２つのプロバイダーをネストして１つのプロバイダーにする
-const CounterProvider = ({ children, initialCount }) => {
-  const { count, increment } = useCounter({ initialCount });
-  return (
-    <CountContext.Provider value={count}>
-      <IncrementContext.Provider value={increment}>
-        {children}
-      </IncrementContext.Provider>
-    </CountContext.Provider>
-  );
-};
-
-const useCount = () => {
-  return useContext(CountContext);
-};
-
-const useIncrement = () => {
-  return useContext(IncrementContext);
-};
+const [CounterProvider, useCount, useIncrement] = constate(
+  useCounter,
+  (value) => value.count,
+  (value) => value.increment
+);
 
 // ボタンコンポーネント
 function IncrementButton() {
@@ -45,7 +28,7 @@ function Count() {
   return <span>{count}</span>;
 }
 
-function DivideContext() {
+function DivideContextWithConstate() {
   return (
     <CounterProvider initialCount={1}>
       <Count />
@@ -54,4 +37,4 @@ function DivideContext() {
   );
 }
 
-export default DivideContext;
+export default DivideContextWithConstate;

--- a/react-context-constate-sandbox/src/index.js
+++ b/react-context-constate-sandbox/src/index.js
@@ -1,6 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import DivideContext from "./DivideContext";
+import DivideContextWithConstate from "./DivideContextWithConstate";
 import OneContext from "./OneContext";
 import OneContextWithReducer from "./OneContextWithReducer";
 
@@ -21,5 +22,9 @@ root.render(
       useState（ボタンをクリックすると、1つのコンポーネントのみレンダリングされる）
     </h2>
     <DivideContext />
+    <h2>
+      constateを使用（ボタンをクリックすると、1つのコンポーネントのみレンダリングされる）
+    </h2>
+    <DivideContextWithConstate />
   </React.StrictMode>
 );

--- a/react-context-constate-sandbox/yarn.lock
+++ b/react-context-constate-sandbox/yarn.lock
@@ -3178,6 +3178,11 @@ connect-history-api-fallback@^2.0.0:
   resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-2.0.0.tgz#647264845251a0daf25b97ce87834cace0f5f1c8"
   integrity sha512-U73+6lQFmfiNPrYbXqr6kZ1i1wiRqXnp2nhMsINseWXO8lDau0LGEffJ8kQi4EjLZympVgRdvqjAgiZ1tgzDDA==
 
+constate@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/constate/-/constate-3.3.2.tgz#a6cd2f3c203da2cb863f47d22a330b833936c449"
+  integrity sha512-ZnEWiwU6QUTil41D5EGpA7pbqAPGvnR9kBjko8DzVIxpC60mdNKrP568tT5WLJPAxAOtJqJw60+h79ot/Uz1+Q==
+
 content-disposition@0.5.4:
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.4.tgz#8b82b4efac82512a02bb0b1dcec9d2c5e8eb5bfe"


### PR DESCRIPTION
With using constate, the component configuration is shown in the following image.

<img width="182" alt="スクリーンショット 2022-11-10 8 23 46" src="https://user-images.githubusercontent.com/49313042/200963715-ddb6a764-c1a8-4354-b9da-8a2fd11728a9.png">


Reference: https://qiita.com/fizumi6/items/224eea88f087e2bb3dd3