### PR TITLE
Redux っぽい、Storeの作成

### DIFF
--- a/mini-redux/src/App.tsx
+++ b/mini-redux/src/App.tsx
@@ -1,8 +1,8 @@
-import React, { useEffect, useReducer } from "react";
+import React from "react";
 import { AppStateStore } from "./AppStateStore";
 import { Article } from "./Article";
 import { GlobalHeader } from "./GlobalHeader";
-import { appStateContext } from "./useAppState";
+import { storeContext } from "./useAppStateStore";
 import { dispatchContext } from "./useDispatch";
 
 const store = new AppStateStore(
@@ -46,25 +46,20 @@ const store = new AppStateStore(
 );
 
 export function App() {
+  console.info("rendering App component");
+
+  // dispatch は値が変化しないので、最上位で定義しておいてok。
   const dispatch = store.dispatch;
-  const appState = store.getState();
-
-  const [, forceUpdate] = useReducer((v) => v + 1, Number.MIN_SAFE_INTEGER);
-  useEffect(() => {
-    const unsubscribe = store.subscribe(forceUpdate);
-
-    return unsubscribe;
-  }, []);
 
   return (
-    <dispatchContext.Provider value={dispatch}>
-      <appStateContext.Provider value={appState}>
+    <storeContext.Provider value={store}>
+      <dispatchContext.Provider value={dispatch}>
         <GlobalHeader />
 
         <Article id="1" />
 
         <Article id="2" />
-      </appStateContext.Provider>
-    </dispatchContext.Provider>
+      </dispatchContext.Provider>
+    </storeContext.Provider>
   );
 }

--- a/mini-redux/src/App.tsx
+++ b/mini-redux/src/App.tsx
@@ -1,49 +1,53 @@
-import React, { useReducer } from "react";
+import React from "react";
+import { AppStateStore } from "./AppStateStore";
 import { Article } from "./Article";
 import { GlobalHeader } from "./GlobalHeader";
-import { AppState, appStateContext } from "./useAppState";
-import { AppAction, dispatchContext } from "./useDispatch";
+import { appStateContext } from "./useAppState";
+import { dispatchContext } from "./useDispatch";
+
+const store = new AppStateStore(
+  (state, action) => {
+    switch (action.type) {
+      case "like": {
+        const { articleId } = action.payload;
+
+        return {
+          ...state,
+          articles: state.articles.map((article) => {
+            if (article.id !== articleId) {
+              return article;
+            }
+
+            return {
+              ...article,
+              likes: article.likes + 1,
+            };
+          }),
+        };
+      }
+    }
+
+    return state;
+  },
+  {
+    articles: [
+      {
+        id: "1",
+        contents: "本来は API などから取得する記事の中身",
+        likes: 0,
+      },
+      {
+        id: "2",
+        contents: "二つ目の記事",
+        likes: 0,
+      },
+    ],
+  }
+);
 
 export function App() {
-  const [appState, dispatch] = useReducer(
-    (state: AppState, action: AppAction) => {
-      switch (action.type) {
-        case "like": {
-          const { articleId } = action.payload;
-
-          return {
-            ...state,
-            articles: state.articles.map((article) => {
-              if (article.id !== articleId) {
-                return article;
-              }
-
-              return {
-                ...article,
-                likes: article.likes + 1,
-              };
-            }),
-          };
-        }
-      }
-
-      return state;
-    },
-    {
-      articles: [
-        {
-          id: "1",
-          contents: "本来は API などから取得する記事の中身",
-          likes: 0,
-        },
-        {
-          id: "2",
-          contents: "二つ目の記事",
-          likes: 0,
-        },
-      ],
-    }
-  );
+  const dispatch = store.dispatch;
+  const appState = store.getState();
 
   return (
     <dispatchContext.Provider value={dispatch}>

--- a/mini-redux/src/App.tsx
+++ b/mini-redux/src/App.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useReducer } from "react";
 import { AppStateStore } from "./AppStateStore";
 import { Article } from "./Article";
 import { GlobalHeader } from "./GlobalHeader";
@@ -48,6 +48,13 @@ const store = new AppStateStore(
 export function App() {
   const dispatch = store.dispatch;
   const appState = store.getState();
+
+  const [, forceUpdate] = useReducer((v) => v + 1, Number.MIN_SAFE_INTEGER);
+  useEffect(() => {
+    const unsubscribe = store.subscribe(forceUpdate);
+
+    return unsubscribe;
+  }, []);
 
   return (
     <dispatchContext.Provider value={dispatch}>

--- a/mini-redux/src/App.tsx
+++ b/mini-redux/src/App.tsx
@@ -3,7 +3,6 @@ import { AppStateStore } from "./AppStateStore";
 import { Article } from "./Article";
 import { GlobalHeader } from "./GlobalHeader";
 import { storeContext } from "./useAppStateStore";
-import { dispatchContext } from "./useDispatch";
 
 const store = new AppStateStore(
   (state, action) => {
@@ -48,18 +47,13 @@ const store = new AppStateStore(
 export function App() {
   console.info("rendering App component");
 
-  // dispatch は値が変化しないので、最上位で定義しておいてok。
-  const dispatch = store.dispatch;
-
   return (
     <storeContext.Provider value={store}>
-      <dispatchContext.Provider value={dispatch}>
-        <GlobalHeader />
+      <GlobalHeader />
 
-        <Article id="1" />
+      <Article id="1" />
 
-        <Article id="2" />
-      </dispatchContext.Provider>
+      <Article id="2" />
     </storeContext.Provider>
   );
 }

--- a/mini-redux/src/AppStateStore.ts
+++ b/mini-redux/src/AppStateStore.ts
@@ -1,6 +1,11 @@
 import { AppState } from "./useAppState";
 import { AppAction } from "./useDispatch";
 
+/**
+ * インスタンスに、appStat を保持させる。
+ * App コンポーネント から useState を剥がし、再レンダリングを最適化するために誕生したクラス。
+ * initialState と reducer関数を渡すことで、インスタンスを作成できる。
+ */
 export class AppStateStore {
   private listeners: (() => void)[] = [];
 

--- a/mini-redux/src/AppStateStore.ts
+++ b/mini-redux/src/AppStateStore.ts
@@ -1,0 +1,17 @@
+import { AppState } from "./useAppState";
+import { AppAction } from "./useDispatch";
+
+export class AppStateStore {
+  constructor(
+    private reducer: (state: AppState, action: AppAction) => AppState,
+    private appState: AppState
+  ) {}
+
+  getState = (): AppState => {
+    return this.appState;
+  };
+
+  dispatch = (action: AppAction) => {
+    this.appState = this.reducer(this.appState, action);
+  };
+}

--- a/mini-redux/src/AppStateStore.ts
+++ b/mini-redux/src/AppStateStore.ts
@@ -2,6 +2,8 @@ import { AppState } from "./useAppState";
 import { AppAction } from "./useDispatch";
 
 export class AppStateStore {
+  private listeners: (() => void)[] = [];
+
   constructor(
     private reducer: (state: AppState, action: AppAction) => AppState,
     private appState: AppState
@@ -13,5 +15,17 @@ export class AppStateStore {
 
   dispatch = (action: AppAction) => {
     this.appState = this.reducer(this.appState, action);
+
+    this.listeners.forEach((listener) => listener());
+  };
+
+  subscribe = (listener: () => void) => {
+    this.listeners.push(listener);
+
+    return () => {
+      const index = this.listeners.lastIndexOf(listener);
+
+      this.listeners.splice(index, 1);
+    };
   };
 }

--- a/mini-redux/src/Article.tsx
+++ b/mini-redux/src/Article.tsx
@@ -1,19 +1,9 @@
-import React, { useEffect, useReducer } from "react";
+import React from "react";
 import { useAppState } from "./useAppState";
-import { useAppStateStore } from "./useAppStateStore";
 import { useDispatch } from "./useDispatch";
 
 export function Article({ id }: { id: string }) {
   console.info("rendering Article component");
-
-  const store = useAppStateStore();
-
-  const [, forceUpdate] = useReducer((v) => v + 1, Number.MIN_SAFE_INTEGER);
-  useEffect(() => {
-    const unsubscribe = store.subscribe(forceUpdate);
-
-    return unsubscribe;
-  }, [store]);
 
   const { articles } = useAppState();
   const dispatch = useDispatch();

--- a/mini-redux/src/Article.tsx
+++ b/mini-redux/src/Article.tsx
@@ -1,8 +1,20 @@
-import React from "react";
+import React, { useEffect, useReducer } from "react";
 import { useAppState } from "./useAppState";
+import { useAppStateStore } from "./useAppStateStore";
 import { useDispatch } from "./useDispatch";
 
 export function Article({ id }: { id: string }) {
+  console.info("rendering Article component");
+
+  const store = useAppStateStore();
+
+  const [, forceUpdate] = useReducer((v) => v + 1, Number.MIN_SAFE_INTEGER);
+  useEffect(() => {
+    const unsubscribe = store.subscribe(forceUpdate);
+
+    return unsubscribe;
+  }, [store]);
+
   const { articles } = useAppState();
   const dispatch = useDispatch();
 

--- a/mini-redux/src/GlobalHeader.tsx
+++ b/mini-redux/src/GlobalHeader.tsx
@@ -1,7 +1,19 @@
-import React from "react";
+import React, { useEffect, useReducer } from "react";
 import { useAppState } from "./useAppState";
+import { useAppStateStore } from "./useAppStateStore";
 
 export function GlobalHeader() {
+  console.info("rendering GlobalHeader component");
+
+  const store = useAppStateStore();
+
+  const [, forceUpdate] = useReducer((v) => v + 1, Number.MIN_SAFE_INTEGER);
+  useEffect(() => {
+    const unsubscribe = store.subscribe(forceUpdate);
+
+    return unsubscribe;
+  }, [store]);
+
   const { articles } = useAppState();
 
   return (

--- a/mini-redux/src/GlobalHeader.tsx
+++ b/mini-redux/src/GlobalHeader.tsx
@@ -1,18 +1,8 @@
-import React, { useEffect, useReducer } from "react";
+import React from "react";
 import { useAppState } from "./useAppState";
-import { useAppStateStore } from "./useAppStateStore";
 
 export function GlobalHeader() {
   console.info("rendering GlobalHeader component");
-
-  const store = useAppStateStore();
-
-  const [, forceUpdate] = useReducer((v) => v + 1, Number.MIN_SAFE_INTEGER);
-  useEffect(() => {
-    const unsubscribe = store.subscribe(forceUpdate);
-
-    return unsubscribe;
-  }, [store]);
 
   const { articles } = useAppState();
 

--- a/mini-redux/src/useAppState.ts
+++ b/mini-redux/src/useAppState.ts
@@ -1,4 +1,4 @@
-import { createContext } from "react";
+import { createContext, useEffect, useReducer } from "react";
 import { useAppStateStore } from "./useAppStateStore";
 
 export interface AppState {
@@ -13,6 +13,14 @@ export const appStateContext = createContext<AppState | null>(null);
 
 export function useAppState() {
   const store = useAppStateStore();
+
+  const [, forceUpdate] = useReducer((v) => v + 1, Number.MIN_SAFE_INTEGER);
+  useEffect(() => {
+    const unsubscribe = store.subscribe(forceUpdate);
+
+    return unsubscribe;
+  }, [store]);
+
   const appState = store.getState();
 
   return appState;

--- a/mini-redux/src/useAppState.ts
+++ b/mini-redux/src/useAppState.ts
@@ -1,4 +1,5 @@
-import { createContext, useContext } from "react";
+import { createContext } from "react";
+import { useAppStateStore } from "./useAppStateStore";
 
 export interface AppState {
   articles: {
@@ -11,10 +12,8 @@ export interface AppState {
 export const appStateContext = createContext<AppState | null>(null);
 
 export function useAppState() {
-  const appState = useContext(appStateContext);
-  if (!appState) {
-    throw new Error("Provider で囲んでください");
-  }
+  const store = useAppStateStore();
+  const appState = store.getState();
 
   return appState;
 }

--- a/mini-redux/src/useAppStateStore.ts
+++ b/mini-redux/src/useAppStateStore.ts
@@ -1,0 +1,13 @@
+import { createContext, useContext } from "react";
+import { AppStateStore } from "./AppStateStore";
+
+export const storeContext = createContext<AppStateStore | null>(null);
+
+export function useAppStateStore() {
+  const store = useContext(storeContext);
+  if (!store) {
+    throw new Error("Provider で囲んでください");
+  }
+
+  return store;
+}

--- a/mini-redux/src/useDispatch.ts
+++ b/mini-redux/src/useDispatch.ts
@@ -1,4 +1,4 @@
-import React, { createContext, useContext } from "react";
+import { useAppStateStore } from "./useAppStateStore";
 
 export type AppAction = {
   type: "like";
@@ -7,15 +7,8 @@ export type AppAction = {
   };
 };
 
-export const dispatchContext = createContext<React.Dispatch<AppAction> | null>(
-  null
-);
-
 export function useDispatch() {
-  const dispatch = useContext(dispatchContext);
-  if (!dispatch) {
-    throw new Error("Provider で囲んでください");
-  }
+  const store = useAppStateStore();
 
-  return dispatch;
+  return store.dispatch;
 }


### PR DESCRIPTION
## 概要

以下の問題を解決するための1つのアプローチを試したもの。

「AppコンポーネントでuseReducerを使用し定義したstateをProviderに渡しているので、そのstateが一部でも変わるとApp配下のコンポーネントはすべて再レンダリングされる」

![スクリーンショット 2022-11-13 12 59 39](https://user-images.githubusercontent.com/49313042/201504977-90aa8b62-07c3-4713-b8f9-d40a8ea7b950.png)

## 方針

- useReducer や useState を使用するのではなく、AppStateStore クラスを作り、そのインスタンスにstateを保持させる
- state を Reactが検知不能な AppStateStore に押し込めてしまったので、Reactがstateの変更を検知できるように forceUpdate 関数を作成する

## 結果

### Before
記事にいいねを押すたびに、Appコンポーネントの console.info("rendering App component"); が発火されていた。つまり毎回Appコンポーネントがレンダリングされていた。

### After
記事にいいねを押すと、Appコンポーネントはレンダリングされず、必要なコンポーネントだけレンダリングされるようになった。

## 参考
[参考サイト](https://zenn.dev/kazuma1989/articles/68c2339e056530#%E5%86%8D%E3%83%AC%E3%83%B3%E3%83%80%E3%83%AA%E3%83%B3%E3%82%B0%E3%82%92%E3%81%A7%E3%81%8D%E3%82%8B%E3%81%A0%E3%81%91%E6%8A%91%E3%81%88%E3%82%8B%EF%BC%88%E5%95%8F%E9%A1%8C-b%EF%BC%89)