### PR TITLE
Redux の `useSelector(selector: Function)` っぽいものを作成

### DIFF
--- a/mini-redux/src/Article.tsx
+++ b/mini-redux/src/Article.tsx
@@ -5,10 +5,11 @@ import { useDispatch } from "./useDispatch";
 export function Article({ id }: { id: string }) {
   console.info("rendering Article component");
 
-  const { articles } = useAppState();
+  const article = useAppState((state) =>
+    state.articles.find((a) => a.id === id)
+  );
   const dispatch = useDispatch();
 
-  const article = articles.find((a) => a.id === id);
   if (!article) {
     return <article>404</article>;
   }

--- a/mini-redux/src/GlobalHeader.tsx
+++ b/mini-redux/src/GlobalHeader.tsx
@@ -4,7 +4,7 @@ import { useAppState } from "./useAppState";
 export function GlobalHeader() {
   console.info("rendering GlobalHeader component");
 
-  const { articles } = useAppState();
+  const articles = useAppState((state) => state.articles);
 
   return (
     <header style={{ padding: 16 }}>

--- a/mini-redux/src/useAppState.ts
+++ b/mini-redux/src/useAppState.ts
@@ -1,4 +1,4 @@
-import { createContext, useEffect, useReducer } from "react";
+import { createContext, useEffect, useReducer, useRef } from "react";
 import { useAppStateStore } from "./useAppStateStore";
 
 export interface AppState {
@@ -9,19 +9,39 @@ export interface AppState {
   }[];
 }
 
+const firstCall = Symbol("firstCall");
+
 export const appStateContext = createContext<AppState | null>(null);
 
-export function useAppState() {
+/** React Redux の useSelector に対応するもの。selector 関数を引数として受け取る。 */
+export function useAppState<T>(selector: (state: AppState) => T): T {
+  const selector$ = useRef(selector);
+  useEffect(() => {
+    selector$.current = selector;
+  });
+
+  const slice$ = useRef<T | typeof firstCall>(firstCall);
+
   const store = useAppStateStore();
 
   const [, forceUpdate] = useReducer((v) => v + 1, Number.MIN_SAFE_INTEGER);
   useEffect(() => {
-    const unsubscribe = store.subscribe(forceUpdate);
+    const unsubscribe = store.subscribe(() => {
+      const freshSlice = selector$.current(store.getState());
+      if (freshSlice === slice$.current) return;
 
+      slice$.current = freshSlice;
+
+      forceUpdate();
+    });
     return unsubscribe;
   }, [store]);
 
-  const appState = store.getState();
+  // 初回だけここで selector を呼ぶ。
+  // 2 回目以降は subscribe したコールバック内で selector を呼んでいるので、呼ぶ必要がない。
+  if (slice$.current === firstCall) {
+    return selector(store.getState());
+  }
 
-  return appState;
+  return slice$.current;
 }

--- a/mini-redux/src/useAppStateStore.ts
+++ b/mini-redux/src/useAppStateStore.ts
@@ -3,6 +3,7 @@ import { AppStateStore } from "./AppStateStore";
 
 export const storeContext = createContext<AppStateStore | null>(null);
 
+/** React Redux の useStore に対応するもの。 */
 export function useAppStateStore() {
   const store = useContext(storeContext);
   if (!store) {

--- a/mini-redux/src/useDispatch.ts
+++ b/mini-redux/src/useDispatch.ts
@@ -7,6 +7,7 @@ export type AppAction = {
   };
 };
 
+/** React Redux の useDispatch に対応するもの。 */
 export function useDispatch() {
   const store = useAppStateStore();
 


### PR DESCRIPTION
## 概要

以下の問題を解決するための1つのアプローチを試したもの。

「appState のうち、それぞれのコンポーネントに必要な値は一部で異なるのに、appState を参照している という理由だけで一律レンダリングを強いられる。」という問題。

例えば、appStateのうち、articles の id が 1のものが更新されたら、それを参照しているコンポーネントだけをレンダリングするようにしたい。

```ts
export interface AppState {
  articles: {
    id: string;
    contents: string;
    likes: number;
  }[];
}
```


## 方針

- appState の全体ではなく一部だけ（slice という）を参照するようにして、その一部に変化がなければ forceUpdate を免除するようにする

## 結果

### Before

Article(id) コンポーネントは、appState全体を参照しているため、記事 1 にいいねを押すと、Article コンポーネントが 2個ともレンダリングされていた。

React Developer Tools で、レンダリングされたコンポーネントをハイライトするようにしている。

https://user-images.githubusercontent.com/49313042/201508824-098255cd-7592-4c36-ae2a-e6b2ae1b537b.mov

### After

useSelector(selector: Function) の形で、Article コンポーネントでは 必要な値だけを切り出して参照するようにした。
```
const article = useAppState((state) =>
    state.articles.find((a) => a.id === id)
);
```

記事 1 にいいねを押すと、記事１を参照している Article コンポーネントと GlobalHeader コンポーネントだけがレンダリングされるようになった。

https://user-images.githubusercontent.com/49313042/201508771-a96a0f5d-7446-42c8-975c-5d5fe44eb5ff.mov


## 参考
[参考サイト](https://zenn.dev/kazuma1989/articles/68c2339e056530#%E5%86%8D%E3%83%AC%E3%83%B3%E3%83%80%E3%83%AA%E3%83%B3%E3%82%B0%E3%82%92%E3%81%A7%E3%81%8D%E3%82%8B%E3%81%A0%E3%81%91%E6%8A%91%E3%81%88%E3%82%8B%EF%BC%88%E5%95%8F%E9%A1%8C-a%EF%BC%89)